### PR TITLE
Implement Storage for DynamoDB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ build/
 *.ipr
 .gradle/
 out/
+
+# DynamoDB
+native-libs/

--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,12 @@
       <artifactId>postgresql</artifactId>
       <version>42.2.2.jre7</version>
     </dependency>
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-dynamodb</artifactId>
+      <version>1.11.362</version>
+    </dependency>
+
   </dependencies>
   <distributionManagement>
     <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -75,8 +75,34 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>2.8</version>
+        <executions>
+          <execution>
+            <id>copy</id>
+            <phase>test-compile</phase>
+            <goals>
+              <goal>copy-dependencies</goal>
+            </goals>
+            <configuration>
+              <includeScope>test</includeScope>
+              <includeTypes>so,dll,dylib</includeTypes>
+              <outputDirectory>${project.basedir}/native-libs</outputDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
+  <repositories>
+    <repository>
+      <id>dynamodb-local-oregon</id>
+      <name>DynamoDB Local Release Repository</name>
+      <url>https://s3-us-west-2.amazonaws.com/dynamodb-local/release</url>
+    </repository>
+  </repositories>
   <dependencies>
     <dependency>
       <groupId>junit</groupId>
@@ -110,12 +136,60 @@
       <artifactId>postgresql</artifactId>
       <version>42.2.2.jre7</version>
     </dependency>
+    <!-- Dependencies for DynamoDB -->
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>DynamoDBLocal</artifactId>
+      <version>[1.11.86,2.0)</version>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-dynamodb</artifactId>
       <version>1.11.362</version>
     </dependency>
-
+    <dependency>
+      <groupId>com.almworks.sqlite4java</groupId>
+      <artifactId>sqlite4java</artifactId>
+      <version>1.0.392</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.almworks.sqlite4java</groupId>
+      <artifactId>sqlite4java-win32-x86</artifactId>
+      <version>1.0.392</version>
+      <type>dll</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.almworks.sqlite4java</groupId>
+      <artifactId>sqlite4java-win32-x64</artifactId>
+      <version>1.0.392</version>
+      <type>dll</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.almworks.sqlite4java</groupId>
+      <artifactId>libsqlite4java-osx</artifactId>
+      <version>1.0.392</version>
+      <type>dylib</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.almworks.sqlite4java</groupId>
+      <artifactId>libsqlite4java-linux-i386</artifactId>
+      <version>1.0.392</version>
+      <type>so</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.almworks.sqlite4java</groupId>
+      <artifactId>libsqlite4java-linux-amd64</artifactId>
+      <version>1.0.392</version>
+      <type>so</type>
+      <scope>test</scope>
+    </dependency>
+    <!-- End of DynamoDB Dependencies -->
   </dependencies>
   <distributionManagement>
     <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -140,12 +140,17 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>DynamoDBLocal</artifactId>
-      <version>[1.11.86,2.0)</version>
+      <version>[1.11,2.0)</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-dynamodb</artifactId>
+      <version>1.11.362</version>
+    </dependency>
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-core</artifactId>
       <version>1.11.362</version>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+      <version>1.10.19</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>io.vlingo</groupId>
       <artifactId>vlingo-common</artifactId>
       <version>0.3.4</version>

--- a/src/main/java/io/vlingo/symbio/store/state/dynamodb/CreateTableInterest.java
+++ b/src/main/java/io/vlingo/symbio/store/state/dynamodb/CreateTableInterest.java
@@ -1,0 +1,7 @@
+package io.vlingo.symbio.store.state.dynamodb;
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsync;
+
+public interface CreateTableInterest {
+    void createTable(AmazonDynamoDBAsync dynamoDBAsync);
+}

--- a/src/main/java/io/vlingo/symbio/store/state/dynamodb/DynamoDBTextStateActor.java
+++ b/src/main/java/io/vlingo/symbio/store/state/dynamodb/DynamoDBTextStateActor.java
@@ -1,0 +1,15 @@
+package io.vlingo.symbio.store.state.dynamodb;
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsync;
+
+public class DynamoDBTextStateActor {
+    private final AmazonDynamoDBAsync dynamodb;
+    private final CreateTableInterest interest;
+
+    public DynamoDBTextStateActor(AmazonDynamoDBAsync dynamodb, CreateTableInterest interest) {
+        this.dynamodb = dynamodb;
+        this.interest = interest;
+
+        interest.createTable(dynamodb);
+    }
+}

--- a/src/main/java/io/vlingo/symbio/store/state/dynamodb/DynamoDBTextStateActor.java
+++ b/src/main/java/io/vlingo/symbio/store/state/dynamodb/DynamoDBTextStateActor.java
@@ -1,8 +1,21 @@
 package io.vlingo.symbio.store.state.dynamodb;
 
+import com.amazonaws.handlers.AsyncHandler;
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsync;
+import com.amazonaws.services.dynamodbv2.model.*;
+import io.vlingo.common.serialization.JsonSerialization;
+import io.vlingo.symbio.State;
+import io.vlingo.symbio.store.state.TextStateStore;
+import io.vlingo.symbio.store.state.dynamodb.handlers.BatchWriteItemAsyncHandler;
+import io.vlingo.symbio.store.state.dynamodb.handlers.GetItemAsyncHandler;
 
-public class DynamoDBTextStateActor {
+import java.util.*;
+import java.util.concurrent.ExecutionException;
+
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
+
+public class DynamoDBTextStateActor implements TextStateStore {
     private final AmazonDynamoDBAsync dynamodb;
     private final CreateTableInterest interest;
 
@@ -11,5 +24,41 @@ public class DynamoDBTextStateActor {
         this.interest = interest;
 
         interest.createTable(dynamodb);
+    }
+
+    @Override
+    public void read(String id, Class<?> type, ReadResultInterest<String> interest) {
+        dynamodb.getItemAsync(readRequestFor(id, type), new GetItemAsyncHandler(interest));
+    }
+
+    @Override
+    public void write(State<String> state, WriteResultInterest<String> interest) {
+        WriteRequest stateForActor = writeRequestFor(state);
+        String tableName = tableFor(state.typed());
+
+        BatchWriteItemRequest request = new BatchWriteItemRequest(singletonMap(tableName, singletonList(stateForActor)));
+        try {
+            dynamodb.batchWriteItemAsync(request, new BatchWriteItemAsyncHandler(state, interest)).get();
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        } catch (ExecutionException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private GetItemRequest readRequestFor(String id, Class<?> type) {
+        String table = tableFor(type);
+        Map<String, AttributeValue> stateItem = StateRecordAdapter.marshallForQuery(id);
+
+        return new GetItemRequest(table, stateItem, true);
+    }
+
+    private WriteRequest writeRequestFor(State<String> state) {
+        Map<String, AttributeValue> stateItem = StateRecordAdapter.marshall(state);
+        return new WriteRequest(new PutRequest(stateItem));
+    }
+
+    private String tableFor(Class<?> type) {
+        return "vlingo_" + type.getCanonicalName().replace(".", "_");
     }
 }

--- a/src/main/java/io/vlingo/symbio/store/state/dynamodb/StateRecordAdapter.java
+++ b/src/main/java/io/vlingo/symbio/store/state/dynamodb/StateRecordAdapter.java
@@ -1,5 +1,47 @@
 package io.vlingo.symbio.store.state.dynamodb;
 
-public final class RecordAdapter {
-    public static
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import io.vlingo.common.serialization.JsonSerialization;
+import io.vlingo.symbio.Metadata;
+import io.vlingo.symbio.State;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public final class StateRecordAdapter {
+    public static Map<String, AttributeValue> marshall(State<String> state) {
+        String metadataAsJson = JsonSerialization.serialized(state.metadata);
+
+        Map<String, AttributeValue> stateItem = new HashMap<>();
+        stateItem.put("Id", new AttributeValue().withS(state.id));
+        stateItem.put("Data", new AttributeValue().withS(state.data));
+        stateItem.put("Type", new AttributeValue().withS(state.type));
+        stateItem.put("Metadata", new AttributeValue().withS(metadataAsJson));
+        stateItem.put("TypeVersion", new AttributeValue().withN(String.valueOf(state.typeVersion)));
+        stateItem.put("DataVersion", new AttributeValue().withN(String.valueOf(state.dataVersion)));
+
+        return stateItem;
+    }
+
+    public static Map<String, AttributeValue> marshallForQuery(String id) {
+        Map<String, AttributeValue> stateItem = new HashMap<>();
+        stateItem.put("Id", new AttributeValue().withS(id));
+
+        return stateItem;
+    }
+
+    public static String unmarshallForId(Map<String, AttributeValue> state) {
+        return state.get("Id").getS();
+    }
+
+    public static State<String> unmarshall(Map<String, AttributeValue> record) throws ClassNotFoundException {
+        return new State.TextState(
+                record.get("Id").getS(),
+                Class.forName(record.get("Type").getS()),
+                Integer.valueOf(record.get("TypeVersion").getN()),
+                record.get("Data").getS(),
+                Integer.valueOf(record.get("DataVersion").getN()),
+                JsonSerialization.deserialized(record.get("Metadata").getS(), Metadata.class)
+        );
+    }
 }

--- a/src/main/java/io/vlingo/symbio/store/state/dynamodb/StateRecordAdapter.java
+++ b/src/main/java/io/vlingo/symbio/store/state/dynamodb/StateRecordAdapter.java
@@ -1,0 +1,5 @@
+package io.vlingo.symbio.store.state.dynamodb;
+
+public final class RecordAdapter {
+    public static
+}

--- a/src/main/java/io/vlingo/symbio/store/state/dynamodb/handlers/BatchWriteItemAsyncHandler.java
+++ b/src/main/java/io/vlingo/symbio/store/state/dynamodb/handlers/BatchWriteItemAsyncHandler.java
@@ -1,0 +1,4 @@
+package io.vlingo.symbio.store.state.dynamodb.handlers;
+
+public class BatchWriteItemAsyncHandler {
+}

--- a/src/main/java/io/vlingo/symbio/store/state/dynamodb/handlers/BatchWriteItemAsyncHandler.java
+++ b/src/main/java/io/vlingo/symbio/store/state/dynamodb/handlers/BatchWriteItemAsyncHandler.java
@@ -1,4 +1,26 @@
 package io.vlingo.symbio.store.state.dynamodb.handlers;
 
-public class BatchWriteItemAsyncHandler {
+import com.amazonaws.handlers.AsyncHandler;
+import com.amazonaws.services.dynamodbv2.model.BatchWriteItemRequest;
+import com.amazonaws.services.dynamodbv2.model.BatchWriteItemResult;
+import io.vlingo.symbio.State;
+import io.vlingo.symbio.store.state.StateStore;
+
+public class BatchWriteItemAsyncHandler implements AsyncHandler<BatchWriteItemRequest, BatchWriteItemResult> {
+    private final State<String> state;
+    private final StateStore.WriteResultInterest<String> interest;
+
+    public BatchWriteItemAsyncHandler(State<String> state, StateStore.WriteResultInterest<String> interest) {
+        this.state = state;
+        this.interest = interest;
+    }
+
+    @Override
+    public void onError(Exception e) {
+    }
+
+    @Override
+    public void onSuccess(BatchWriteItemRequest request, BatchWriteItemResult batchWriteItemResult) {
+        interest.writeResultedIn(StateStore.Result.Success, state.id, state);
+    }
 }

--- a/src/main/java/io/vlingo/symbio/store/state/dynamodb/handlers/GetItemAsyncHandler.java
+++ b/src/main/java/io/vlingo/symbio/store/state/dynamodb/handlers/GetItemAsyncHandler.java
@@ -1,0 +1,4 @@
+package io.vlingo.symbio.store.state.dynamodb.handlers;
+
+public class GetItemAsyncHandler {
+}

--- a/src/main/java/io/vlingo/symbio/store/state/dynamodb/handlers/GetItemAsyncHandler.java
+++ b/src/main/java/io/vlingo/symbio/store/state/dynamodb/handlers/GetItemAsyncHandler.java
@@ -1,4 +1,38 @@
 package io.vlingo.symbio.store.state.dynamodb.handlers;
 
-public class GetItemAsyncHandler {
+import com.amazonaws.handlers.AsyncHandler;
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import com.amazonaws.services.dynamodbv2.model.GetItemRequest;
+import com.amazonaws.services.dynamodbv2.model.GetItemResult;
+import io.vlingo.symbio.State;
+import io.vlingo.symbio.store.state.StateStore;
+import io.vlingo.symbio.store.state.dynamodb.StateRecordAdapter;
+
+import java.util.Map;
+
+public class GetItemAsyncHandler implements AsyncHandler<GetItemRequest, GetItemResult> {
+    private final StateStore.ReadResultInterest<String> interest;
+
+    public GetItemAsyncHandler(StateStore.ReadResultInterest<String> interest) {
+        this.interest = interest;
+    }
+
+    @Override
+    public void onError(Exception e) {
+
+    }
+
+    @Override
+    public void onSuccess(GetItemRequest request, GetItemResult getItemResult) {
+        Map<String, AttributeValue> item = getItemResult.getItem();
+        try {
+            State<String> state = StateRecordAdapter.unmarshall(item);
+            interest.readResultedIn(StateStore.Result.Success, state.id, state);
+        } catch (ClassNotFoundException e) {
+            interest.readResultedIn(StateStore.Result.Failure,
+                    StateRecordAdapter.unmarshallForId(item),
+                    (State) new State.NullState()
+            );
+        }
+    }
 }

--- a/src/test/java/io/vlingo/symbio/store/state/dynamodb/DynamoDBTextStateActorTest.java
+++ b/src/test/java/io/vlingo/symbio/store/state/dynamodb/DynamoDBTextStateActorTest.java
@@ -1,19 +1,135 @@
 package io.vlingo.symbio.store.state.dynamodb;
 
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.AnonymousAWSCredentials;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsync;
-import org.junit.Test;
-import org.mockito.Mockito;
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsyncClient;
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder;
+import com.amazonaws.services.dynamodbv2.document.Table;
+import com.amazonaws.services.dynamodbv2.local.main.ServerRunner;
+import com.amazonaws.services.dynamodbv2.local.server.DynamoDBProxyServer;
+import com.amazonaws.services.dynamodbv2.model.*;
+import io.vlingo.symbio.Metadata;
+import io.vlingo.symbio.State;
+import io.vlingo.symbio.store.state.Entity1;
+import io.vlingo.symbio.store.state.StateStore;
+import org.junit.*;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+import static java.util.Arrays.asList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 
 public class DynamoDBTextStateActorTest {
+    private static final String DYNAMODB_HOST = "http://localhost:8000";
+    private static final String DYNAMODB_REGION = "eu-west-1";
+    private static final AWSStaticCredentialsProvider DYNAMODB_CREDENTIALS = new AWSStaticCredentialsProvider(new BasicAWSCredentials("1", "2"));
+    private static final AwsClientBuilder.EndpointConfiguration DYNAMODB_ENDPOINT_CONFIGURATION = new AwsClientBuilder.EndpointConfiguration(DYNAMODB_HOST, DYNAMODB_REGION);
+    private static final String TABLE_NAME = "vlingo_io_vlingo_symbio_store_state_Entity1";
+
+    private AmazonDynamoDBAsync dynamodb;
+    private static DynamoDBProxyServer dynamodbServer;
+    private CreateTableInterest createTableInterest;
+    private DynamoDBTextStateActor actor;
+    private StateStore.WriteResultInterest<String> writeResultInterest;
+    private StateStore.ReadResultInterest<String> readResultInterest;
+
+    @BeforeClass
+    public static void setUpDynamoDB() throws Exception {
+        System.setProperty("sqlite4java.library.path", "native-libs");
+        final String[] localArgs = { "-inMemory" };
+
+        dynamodbServer = ServerRunner.createServerFromCommandLineArgs(localArgs);
+        dynamodbServer.start();
+    }
+
+    @AfterClass
+    public static void tearDownDynamoDb() throws Exception {
+        dynamodbServer.stop();
+    }
+
+    @Before
+    public void setUp() {
+        createTable();
+
+        dynamodb = AmazonDynamoDBAsyncClient.asyncBuilder()
+                .withCredentials(DYNAMODB_CREDENTIALS)
+                .withEndpointConfiguration(DYNAMODB_ENDPOINT_CONFIGURATION)
+                .build();
+
+        createTableInterest = mock(CreateTableInterest.class);
+        writeResultInterest = mock(StateStore.WriteResultInterest.class);
+        readResultInterest = mock(StateStore.ReadResultInterest.class);
+
+        actor = new DynamoDBTextStateActor(dynamodb, createTableInterest);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        dropTable();
+    }
+
     @Test
     public void testThatInterestIsCalledForCreatingATable() {
-        AmazonDynamoDBAsync dynamodb = Mockito.mock(AmazonDynamoDBAsync.class);
-        CreateTableInterest interest = Mockito.mock(CreateTableInterest.class);
+        verify(createTableInterest).createTable(dynamodb);
+    }
 
-        DynamoDBTextStateActor actor = new DynamoDBTextStateActor(dynamodb, interest);
+    @Test
+    public void testThatWritingAndReadingTransactionReturnsCurrentState() throws Exception {
+        State<String> currentState = randomState();
+        actor.write(currentState, writeResultInterest);
+        actor.read(currentState.id, currentState.typed(), readResultInterest);
 
-        verify(interest).createTable(dynamodb);
+        verify(writeResultInterest, timeout(50)).writeResultedIn(StateStore.Result.Success, currentState.id, currentState);
+        verify(readResultInterest, timeout(50)).readResultedIn(StateStore.Result.Success, currentState.id, currentState);
+    }
+
+    private State<String> randomState() {
+        return new State.TextState(
+                UUID.randomUUID().toString(),
+                Entity1.class,
+                1,
+                UUID.randomUUID().toString(),
+                1,
+                new Metadata(UUID.randomUUID().toString(), UUID.randomUUID().toString())
+        );
+    }
+
+    private void createTable() {
+        AmazonDynamoDB syncDynamoDb = AmazonDynamoDBClientBuilder.standard()
+                .withEndpointConfiguration(DYNAMODB_ENDPOINT_CONFIGURATION)
+                .withCredentials(DYNAMODB_CREDENTIALS)
+                .build();
+
+        List<AttributeDefinition> attributeDefinitions= new ArrayList<>();
+        attributeDefinitions.add(new AttributeDefinition().withAttributeName("Id").withAttributeType("S"));
+
+        List<KeySchemaElement> keySchema = new ArrayList<>();
+        keySchema.add(new KeySchemaElement().withAttributeName("Id").withKeyType(KeyType.HASH));
+
+        CreateTableRequest request = new CreateTableRequest()
+                .withTableName(TABLE_NAME)
+                .withKeySchema(keySchema)
+                .withAttributeDefinitions(attributeDefinitions)
+                .withProvisionedThroughput(new ProvisionedThroughput(1L, 1L));
+
+        syncDynamoDb.createTable(request);
+    }
+
+    private void dropTable() {
+        AmazonDynamoDB syncDynamoDb = AmazonDynamoDBClientBuilder.standard()
+                .withEndpointConfiguration(DYNAMODB_ENDPOINT_CONFIGURATION)
+                .withCredentials(DYNAMODB_CREDENTIALS)
+                .build();
+
+        syncDynamoDb.deleteTable(TABLE_NAME);
     }
 }

--- a/src/test/java/io/vlingo/symbio/store/state/dynamodb/DynamoDBTextStateActorTest.java
+++ b/src/test/java/io/vlingo/symbio/store/state/dynamodb/DynamoDBTextStateActorTest.java
@@ -1,0 +1,19 @@
+package io.vlingo.symbio.store.state.dynamodb;
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsync;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.mockito.Mockito.verify;
+
+public class DynamoDBTextStateActorTest {
+    @Test
+    public void testThatInterestIsCalledForCreatingATable() {
+        AmazonDynamoDBAsync dynamodb = Mockito.mock(AmazonDynamoDBAsync.class);
+        CreateTableInterest interest = Mockito.mock(CreateTableInterest.class);
+
+        DynamoDBTextStateActor actor = new DynamoDBTextStateActor(dynamodb, interest);
+
+        verify(interest).createTable(dynamodb);
+    }
+}


### PR DESCRIPTION
**[WIP]** Solves issue #1 

This is a basic implementation of a DynamoDB state store using the asynchronous DynamoDB client.

**Notes:**
* I've added a CreateTableInterest when writing in case someone wants to create DynamoDB tables programmatically. However, using Cloudformation is the desired way.
* It uses the Asynchronous Client
* Tests are integration tests with a in-memory dynamodb to ensure that everything is working. This follows the current JDBC conventions for testing. Sadly this has some 'uncomfortable' requirements, like some sqlite dependencies and maven plugins (see pom.xml changes).
* It uses a table per each entity class. The format is: vlingo_${FULL_QUALIFIED_CLASS_NAME_WITH_UNDERSCORES_INSTEAD_OF_DOTS}. There is an example on the test class. 
* State.NullState implements State<Object>. Java generics are not covariant, so I can not use State.NullState as valid implementation of State<String>. I used null at this point, but it should be solved somehow.
* I didn't find a way to use Read/Write*Interest to share the exception with the caller.

**Current State:**
- [x] Write State<String> to a DynamoDB Table
- [x] Read State<String> from a DynamoDB Table
- [x] Handle errors when record does not exist during a read operation
- [x] Handle errors when a table does not exist during a write operation
- [x] Handle errors when a table does not exist during a read operation
- [x] Notify CreateTableInterest when writing a record (as we need a table)
- [x] Implement a NoopCreateTableInterest
- [ ] Handle versioning on writing

Please, give some feedback if you find any issues on the current implementation.