### PR TITLE
Make Journal factory work with implementations that do not use the dispatcher directly

### DIFF
--- a/src/main/java/io/vlingo/symbio/store/journal/Journal.java
+++ b/src/main/java/io/vlingo/symbio/store/journal/Journal.java
@@ -77,6 +77,22 @@ public interface Journal<T> {
   }
 
   /**
+   * Answer a new {@code Journal<T>}
+   * @param stage the Stage within which the {@code Journal<T>} is created
+   * @param implementor the {@code Class<A>} of the implementor
+   * @param additional the Object[] of additional parameters
+   * @param <A> the concrete type of the Actor implementing the {@code Journal<T>} protocol
+   * @param <T> the concrete type of {@code Entry<T>} stored and read, which maybe be String, byte[], or Object
+   * @return {@code Journal<T>}
+   */
+  @SuppressWarnings("unchecked")
+  static <A extends Actor, T> Journal<T> using(final Stage stage, final Class<A> implementor, final Object...additional) {
+    return additional.length == 0 ?
+            stage.actorFor(Journal.class, implementor) :
+            stage.actorFor(Journal.class, implementor, additional);
+  }
+
+  /**
    * The means by which the {@code Journal<T>} informs the sender of the result of any given append.
    */
   public static interface AppendResultInterest {


### PR DESCRIPTION
Addresses #25

For example, `JDBCJournalActor` now requires two arguments: `JDBCJournalInstantWriter` and `Configuration`. It no longer requires `Dispatcher`.

This patch makes the following work:

```java
Journal.using(stage, JDBCJournalActor.class, configuration, journalInstantWriter)
```

Any client code still needs to be updated to provide the `JDBCJournalInstantWriter` instead of `Dispatcher`. I will take a look at `vlingo-symbio-jdbc` to see if it's possible to introduce backwards compatibility.
