### PR TITLE
Allow to override the default redispatch delay

### DIFF
--- a/src/main/java/io/vlingo/symbio/store/dispatch/DispatcherControl.java
+++ b/src/main/java/io/vlingo/symbio/store/dispatch/DispatcherControl.java
@@ -55,21 +55,42 @@ public interface DispatcherControl {
 
   public static class DispatcherControlInstantiator<ET extends Entry<?>, ST extends State<?>> implements ActorInstantiator<DispatcherControlActor> {
     private static final long serialVersionUID = 1739556269104244158L;
+    private static final long DEFAULT_REDISPATCH_DELAY = 2000L;
 
     private final List<Dispatcher<Dispatchable<? extends Entry<?>, ? extends State<?>>>> dispatchers;
     private final DispatcherControlDelegate<? extends Entry<?>, ? extends State<?>> delegate;
+    private final long redispatchDelay;
     private final long checkConfirmationExpirationInterval;
     private final long confirmationExpiration;
 
     public DispatcherControlInstantiator(
             final List<Dispatcher<Dispatchable<? extends Entry<?>, ? extends State<?>>>> dispatchers,
             final DispatcherControlDelegate<? extends Entry<?>, ? extends State<?>> delegate,
+            final long redispatchDelay,
             final long checkConfirmationExpirationInterval,
             final long confirmationExpiration) {
       this.dispatchers = dispatchers;
       this.delegate = delegate;
+      this.redispatchDelay = redispatchDelay;
       this.checkConfirmationExpirationInterval = checkConfirmationExpirationInterval;
       this.confirmationExpiration = confirmationExpiration;
+    }
+
+    public DispatcherControlInstantiator(
+            final List<Dispatcher<Dispatchable<? extends Entry<?>, ? extends State<?>>>> dispatchers,
+            final DispatcherControlDelegate<? extends Entry<?>, ? extends State<?>> delegate,
+            final long checkConfirmationExpirationInterval,
+            final long confirmationExpiration) {
+      this(dispatchers, delegate, DEFAULT_REDISPATCH_DELAY, checkConfirmationExpirationInterval, confirmationExpiration);
+    }
+
+    public DispatcherControlInstantiator(
+            final Dispatcher<Dispatchable<? extends Entry<?>, ? extends State<?>>> dispatcher,
+            final DispatcherControlDelegate<? extends Entry<?>, ? extends State<?>> delegate,
+            final long redispatchDelay,
+            final long checkConfirmationExpirationInterval,
+            final long confirmationExpiration) {
+      this(Arrays.asList(dispatcher), delegate, redispatchDelay, checkConfirmationExpirationInterval, confirmationExpiration);
     }
 
     public DispatcherControlInstantiator(
@@ -85,6 +106,7 @@ public interface DispatcherControl {
       return new DispatcherControlActor(
               dispatchers,
               delegate,
+              redispatchDelay,
               checkConfirmationExpirationInterval,
               confirmationExpiration);
     }

--- a/src/main/java/io/vlingo/symbio/store/dispatch/control/DispatcherControlActor.java
+++ b/src/main/java/io/vlingo/symbio/store/dispatch/control/DispatcherControlActor.java
@@ -23,8 +23,6 @@ import io.vlingo.symbio.store.dispatch.Dispatcher;
 import io.vlingo.symbio.store.dispatch.DispatcherControl;
 
 public class DispatcherControlActor extends Actor implements DispatcherControl, Scheduled<Object> {
-  private final static long DEFAULT_REDISPATCH_DELAY = 2000L;
-
   private final List<Dispatcher<Dispatchable<? extends Entry<?>, ? extends State<?>>>> dispatchers;
   private final DispatcherControlDelegate<? extends Entry<?>, ? extends State<?>> delegate;
   private final Cancellable cancellable;
@@ -33,22 +31,15 @@ public class DispatcherControlActor extends Actor implements DispatcherControl, 
   public DispatcherControlActor(
           final List<Dispatcher<Dispatchable<? extends Entry<?>, ? extends State<?>>>> dispatchers,
           final DispatcherControlDelegate<? extends Entry<?>, ? extends State<?>> delegate,
+          final long redispatchDelay,
           final long checkConfirmationExpirationInterval,
           final long confirmationExpiration) {
     this.dispatchers = dispatchers;
     this.delegate = delegate;
     this.confirmationExpiration = confirmationExpiration;
-    this.cancellable = scheduler().schedule(this, null, DEFAULT_REDISPATCH_DELAY, checkConfirmationExpirationInterval);
+    this.cancellable = scheduler().schedule(this, null, redispatchDelay, checkConfirmationExpirationInterval);
     this.dispatchers.forEach(d -> d.controlWith(this));
   }
-
-//  public DispatcherControlActor(
-//          final Dispatcher<Dispatchable<? extends Entry<?>, ? extends State<?>>> dispatcher,
-//          final DispatcherControlDelegate<? extends Entry<?>, ? extends State<?>> delegate,
-//          final long checkConfirmationExpirationInterval,
-//          final long confirmationExpiration) {
-//    this(Arrays.asList(dispatcher), delegate, checkConfirmationExpirationInterval, confirmationExpiration);
-//  }
 
   @Override
   public void intervalSignal(final Scheduled<Object> scheduled, final Object data) {


### PR DESCRIPTION
When processing big batches of dispatchables it might happen that the default initial delay kicks in too quickly. As a result, the batch that's still being dispatched is dispatched again. 